### PR TITLE
Add JWT-based SSO demo with auth and client services

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-# mcdp-sso
+# SSO Demo
+
+This repository contains three Spring Boot services demonstrating custom JWT-based SSO:
+
+- **auth-server** – issues JWT tokens after basic authentication.
+- **service1** – resource server exposing `/service1/hello`.
+- **service2** – resource server exposing `/service2/greet`.
+
+## Running
+
+Build and start each service in separate terminals:
+
+```bash
+mvn -q -f auth-server/pom.xml spring-boot:run
+mvn -q -f service1/pom.xml spring-boot:run
+mvn -q -f service2/pom.xml spring-boot:run
+```
+
+Retrieve a token from the authentication server:
+
+```bash
+curl -u user:password -X POST http://localhost:9000/auth/token
+```
+
+Call the protected endpoints using the token:
+
+```bash
+curl -H "Authorization: Bearer <token>" http://localhost:9001/service1/hello
+curl -H "Authorization: Bearer <token>" http://localhost:9002/service2/greet
+```

--- a/auth-server/pom.xml
+++ b/auth-server/pom.xml
@@ -1,0 +1,53 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.2.4</version>
+    <relativePath/>
+  </parent>
+  <groupId>com.example</groupId>
+  <artifactId>auth-server</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <name>auth-server</name>
+  <description>Authentication server issuing JWT tokens</description>
+  <properties>
+    <java.version>17</java.version>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-api</artifactId>
+      <version>0.11.5</version>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-impl</artifactId>
+      <version>0.11.5</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-jackson</artifactId>
+      <version>0.11.5</version>
+      <scope>runtime</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/auth-server/src/main/java/com/example/auth/AuthServerApplication.java
+++ b/auth-server/src/main/java/com/example/auth/AuthServerApplication.java
@@ -1,0 +1,11 @@
+package com.example.auth;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class AuthServerApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(AuthServerApplication.class, args);
+    }
+}

--- a/auth-server/src/main/java/com/example/auth/config/SecurityConfig.java
+++ b/auth-server/src/main/java/com/example/auth/config/SecurityConfig.java
@@ -1,0 +1,31 @@
+package com.example.auth.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.csrf(csrf -> csrf.disable())
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/auth/token").authenticated()
+                .anyRequest().denyAll())
+            .httpBasic(Customizer.withDefaults());
+        return http.build();
+    }
+
+    @Bean
+    public UserDetailsService users() {
+        return new InMemoryUserDetailsManager(
+            User.withUsername("user").password("{noop}password").roles("USER").build()
+        );
+    }
+}

--- a/auth-server/src/main/java/com/example/auth/controller/AuthController.java
+++ b/auth-server/src/main/java/com/example/auth/controller/AuthController.java
@@ -1,0 +1,33 @@
+package com.example.auth.controller;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import javax.crypto.SecretKey;
+
+@RestController
+@RequestMapping("/auth")
+public class AuthController {
+
+    private final SecretKey key = Keys.hmacShaKeyFor("mysecretmysecretmysecretmysec".getBytes());
+
+    @PostMapping("/token")
+    public String token(Authentication authentication) {
+        Instant now = Instant.now();
+        return Jwts.builder()
+                .setSubject(authentication.getName())
+                .claim("authorities", authentication.getAuthorities())
+                .setIssuedAt(Date.from(now))
+                .setExpiration(Date.from(now.plus(30, ChronoUnit.MINUTES)))
+                .signWith(key)
+                .compact();
+    }
+}

--- a/auth-server/src/main/resources/application.properties
+++ b/auth-server/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+server.port=9000

--- a/service1/pom.xml
+++ b/service1/pom.xml
@@ -1,0 +1,40 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.2.4</version>
+    <relativePath/>
+  </parent>
+  <groupId>com.example</groupId>
+  <artifactId>service1</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <name>service1</name>
+  <description>Client service 1 protected by JWT</description>
+  <properties>
+    <java.version>17</java.version>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/service1/src/main/java/com/example/service1/Service1Application.java
+++ b/service1/src/main/java/com/example/service1/Service1Application.java
@@ -1,0 +1,11 @@
+package com.example.service1;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Service1Application {
+    public static void main(String[] args) {
+        SpringApplication.run(Service1Application.class, args);
+    }
+}

--- a/service1/src/main/java/com/example/service1/config/SecurityConfig.java
+++ b/service1/src/main/java/com/example/service1/config/SecurityConfig.java
@@ -1,0 +1,31 @@
+package com.example.service1.config;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+import io.jsonwebtoken.security.Keys;
+
+@Configuration
+public class SecurityConfig {
+
+    private final SecretKey key = Keys.hmacShaKeyFor("mysecretmysecretmysecretmysec".getBytes());
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.csrf(csrf -> csrf.disable())
+            .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+            .oauth2ResourceServer(oauth -> oauth.jwt(jwt -> jwt.decoder(jwtDecoder())));
+        return http.build();
+    }
+
+    @Bean
+    public JwtDecoder jwtDecoder() {
+        return NimbusJwtDecoder.withSecretKey(key).build();
+    }
+}

--- a/service1/src/main/java/com/example/service1/controller/HelloController.java
+++ b/service1/src/main/java/com/example/service1/controller/HelloController.java
@@ -1,0 +1,15 @@
+package com.example.service1.controller;
+
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloController {
+
+    @GetMapping("/service1/hello")
+    public String hello(@AuthenticationPrincipal Jwt jwt) {
+        return "Hello " + jwt.getSubject() + " from Service 1";
+    }
+}

--- a/service1/src/main/resources/application.properties
+++ b/service1/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+server.port=9001

--- a/service2/pom.xml
+++ b/service2/pom.xml
@@ -1,0 +1,40 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.2.4</version>
+    <relativePath/>
+  </parent>
+  <groupId>com.example</groupId>
+  <artifactId>service2</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <name>service2</name>
+  <description>Client service 2 protected by JWT</description>
+  <properties>
+    <java.version>17</java.version>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/service2/src/main/java/com/example/service2/Service2Application.java
+++ b/service2/src/main/java/com/example/service2/Service2Application.java
@@ -1,0 +1,11 @@
+package com.example.service2;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Service2Application {
+    public static void main(String[] args) {
+        SpringApplication.run(Service2Application.class, args);
+    }
+}

--- a/service2/src/main/java/com/example/service2/config/SecurityConfig.java
+++ b/service2/src/main/java/com/example/service2/config/SecurityConfig.java
@@ -1,0 +1,31 @@
+package com.example.service2.config;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+import io.jsonwebtoken.security.Keys;
+
+@Configuration
+public class SecurityConfig {
+
+    private final SecretKey key = Keys.hmacShaKeyFor("mysecretmysecretmysecretmysec".getBytes());
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.csrf(csrf -> csrf.disable())
+            .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+            .oauth2ResourceServer(oauth -> oauth.jwt(jwt -> jwt.decoder(jwtDecoder())));
+        return http.build();
+    }
+
+    @Bean
+    public JwtDecoder jwtDecoder() {
+        return NimbusJwtDecoder.withSecretKey(key).build();
+    }
+}

--- a/service2/src/main/java/com/example/service2/controller/GreetingController.java
+++ b/service2/src/main/java/com/example/service2/controller/GreetingController.java
@@ -1,0 +1,15 @@
+package com.example.service2.controller;
+
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class GreetingController {
+
+    @GetMapping("/service2/greet")
+    public String greet(@AuthenticationPrincipal Jwt jwt) {
+        return "Greetings " + jwt.getSubject() + " from Service 2";
+    }
+}

--- a/service2/src/main/resources/application.properties
+++ b/service2/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+server.port=9002


### PR DESCRIPTION
## Summary
- add authentication server issuing JWT tokens
- add two resource services validating JWT for SSO
- document running and usage

## Testing
- `mvn -q -f auth-server/pom.xml test` *(fails: Non-resolvable parent POM; network is unreachable)*
- `mvn -q -f service1/pom.xml test` *(fails: Non-resolvable parent POM; network is unreachable)*
- `mvn -q -f service2/pom.xml test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ba8159b66083239aeb4056d32d89db